### PR TITLE
Handle gaps in array keys

### DIFF
--- a/src/Fuse.php
+++ b/src/Fuse.php
@@ -51,6 +51,7 @@ class Fuse
 
     public function setCollection($list)
     {
+        $list = array_values($list);
         $this->list = $list;
         return $list;
     }


### PR DESCRIPTION
Fixes https://github.com/Loilo/Fuse/issues/14

BTW i checked the https://github.com/krisk/Fuse and i saw that you are following the code structure and the code it self. That is nice and i guess it helps a lot in maintaining this port to php.

That is why i preferred to make this PR, instead of the code below to preserve the similarity between the js implementation and the php one

```php
    public function setCollection($list)
    {
        return $this->list = array_values($list);
    }
```

I even committed that first https://github.com/shadoWalker89/Fuse/commit/55759bd8b941cbd5f2a361f7869d021669627af7 on my fork and then switched to the current change in this PR