### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
         }
     ],
     "require": {
-        "php": ">= 5.6"
+        "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^5.6 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0 || ^8.0"
+        "phpunit/phpunit": "^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With this update the package only supports 5+ and 7+ and wont break in future major releases such as version 8.

This update also allows different versions of PHPUnit.