### PR TITLE
Exclude non-essential .github directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto eol=lf
 
 /test export-ignore
+/.github export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
This will remove the `.github` directory in production.