### PR TITLE
Move KeyType to its own file

### DIFF
--- a/src/Core/KeyType.php
+++ b/src/Core/KeyType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Fuse\Core;
+
+class KeyType
+{
+    const PATH = '$path';
+    const PATTERN = '$val';
+}

--- a/src/Core/parse.php
+++ b/src/Core/parse.php
@@ -8,12 +8,6 @@ use Fuse\Tools\KeyStore;
 
 use function Fuse\Helpers\Types\{isArray, isAssoc};
 
-class KeyType
-{
-    const PATH = '$path';
-    const PATTERN = '$val';
-}
-
 function isExpression(array $query): bool
 {
     return isset($query[LogicalOperator::AND]) || isset($query[LogicalOperator::OR]);
@@ -37,7 +31,7 @@ function isLeaf(array $query): bool
 function convertToExplicit(array $query): array
 {
     return [
-        LogicalOperator::AND => array_map(fn($key) => [$key => $query[$key]], array_keys($query)),
+        LogicalOperator::AND => array_map(fn ($key) => [$key => $query[$key]], array_keys($query)),
     ];
 }
 


### PR DESCRIPTION
This PR will fix the following warning when you install the latest version of this package:

> Class Fuse\Core\KeyType located in ./vendor/loilo/fuse/src/Core/parse.php does not comply with psr-4 autoloading standard. Skipping.

Side note: thanks for keeping the package up to date 🙌 