### PR TITLE
fix: enforce compatibility with JsonSerializable::jsonSerialize() in KeyStore & FuseIndex

### DIFF
--- a/src/Tools/FuseIndex.php
+++ b/src/Tools/FuseIndex.php
@@ -216,7 +216,7 @@ class FuseIndex implements JsonSerializable
         $this->records[] = $record;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'keys' => $this->keys,

--- a/src/Tools/KeyStore.php
+++ b/src/Tools/KeyStore.php
@@ -93,7 +93,7 @@ class KeyStore implements JsonSerializable
         return $this->keys;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->keys;
     }


### PR DESCRIPTION
Prevents deprecation notices in fresh PHP versions.

Supposedly deprecated errors start with 8.1, but proposed changes are compatible with 7.4

```
Deprecated: Return type of Fuse\Tools\KeyStore::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/loilo/fuse/src/Tools/KeyStore.php on line 96
...
Deprecated: Return type of Fuse\Tools\FuseIndex::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/loilo/fuse/src/Tools/FuseIndex.php on line 219
```