### PR TITLE
Allowing adding real objects or arrays, and not only arrays.

### DIFF
--- a/src/Tools/FuseIndex.php
+++ b/src/Tools/FuseIndex.php
@@ -157,7 +157,7 @@ class FuseIndex implements JsonSerializable
         $this->records[] = $record;
     }
 
-    private function addObject(array $doc, int $docIndex): void
+    private function addObject($doc, int $docIndex): void
     {
         $record = [
             'i' => $docIndex,

--- a/test/FuzzySearch/ObjectValuesTest.php
+++ b/test/FuzzySearch/ObjectValuesTest.php
@@ -29,7 +29,7 @@ class ObjectValuesTest extends TestCase
         $fuse = new Fuse(
             [
                 new TestObject(["name" => "foo"]),
-                new TestObject(["name" => "foo"]),
+                new TestObject(["name" => "bar"]),
             ],
             [
                 'keys' => [

--- a/test/FuzzySearch/ObjectValuesTest.php
+++ b/test/FuzzySearch/ObjectValuesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fuse\Test;
+
+use PHPUnit\Framework\TestCase;
+use Fuse\Fuse;
+
+class TestObject
+{
+    private $array = [];
+
+    public function __construct($array)
+    {
+        $this->array = !empty($array) ? $array : [];
+    }
+
+    function get($key)
+    {
+        return isset($this->array[$key]) ? $this->array[$key] : null;
+    }
+}
+
+class ObjectValuesTest extends TestCase
+{
+    public function testObjectsAreProcessed(): void
+    {
+        $fuse = new Fuse(
+            [
+                new TestObject(["name" => "foo"]),
+                new TestObject(["name" => "foo"]),
+            ],
+            [
+                'keys' => [
+                    [
+                        'name' => 'name',
+                        'getFn' => function ($document) {
+                            return $document->get('name');
+                        }
+                    ],
+                ],
+            ],
+        );
+
+        $result = $fuse->search('foo');
+
+        $this->assertCount(1, $result);
+    }
+}


### PR DESCRIPTION
Hi loilo,

I've been using this library (FuseJS) for a while and is working great, this PHP port is great and it is working for me, except when parsing an Array of Objects. 

The function addObject, doesn't really allow to add an object, just an array.

This small change will fix that.